### PR TITLE
add filesNotMatching to avoid corrupted png

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,10 +52,12 @@ if (!project.hasProperty('release.useLastTag')) {
 }
 
 processResources.configure {
-  filter ReplaceTokens, tokens: [
-    'project.version': version.toString(),
-    'project.name'   : rootProject.name
-  ]
+  filesNotMatching('**/*.png') {
+    filter ReplaceTokens, tokens: [
+      'project.version': version.toString(),
+      'project.name'   : rootProject.name
+    ]
+  }
 }
 
 license {


### PR DESCRIPTION
png files are corrupted during a gradle build